### PR TITLE
fix(api): remove dead imports and redundant env init for cold start optimization

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,20 +1,3 @@
-import * as dotenv from 'dotenv';
-import * as path from 'path';
-import { fileURLToPath } from 'url';
-
-// ── ENVIRONMENT INITIALIZATION ──────────────────────────────────────
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const rootPath = path.resolve(__dirname, '../../../');
-
-if (process.env.NODE_ENV !== 'production') {
-  const envPath = path.join(rootPath, '.env');
-  const envLocalPath = path.join(rootPath, '.env.local');
-
-  dotenv.config({ path: envPath, override: true });
-  dotenv.config({ path: envLocalPath, override: true });
-}
-
 // ── INSTRUMENTATION ──────────────────────────────────────────────────
 // Only load Sentry in Node.js fallback if DSN is present.
 // For Cloudflare Workers, use @sentry/cloudflare middleware if needed.


### PR DESCRIPTION
## Summary
- Remove `dotenv`, `path`, and `url` imports that are not needed in production
- Remove the env initialization block (`.env` / `.env.local` loading) which only runs in dev
- Reduces cold start overhead on Vercel serverless functions

## Related
Closes #97