### PR TITLE
fix(api): raise auth route rate limit from 10 to 30 req/min

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -138,8 +138,8 @@ v1.get('/health', (c) => {
   });
 });
 
-// Auth routes — strict rate limit for brute force protection (10 req/min per IP)
-app.use('/api/auth/*', rateLimitMiddleware({ limit: 10, windowMs: 60_000 }));
+// Auth routes — strict rate limit for brute force protection (30 req/min per IP)
+app.use('/api/auth/*', rateLimitMiddleware({ limit: 30, windowMs: 60_000 }));
 app.route('/api/auth', authRoutes);
 app.route('/api/v1', v1);
 


### PR DESCRIPTION
## Summary
- Increase rate limit on `/api/auth/*` from 10 to 30 requests per minute
- Prevents false rate-limit blocks during social login when Firebase observer
  triggers multiple consecutive requests to sync user state

## Related
Closes #99