### PR TITLE
fix(api): add success:false to 429 rate limit error response

### DIFF
--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -77,6 +77,7 @@ export function rateLimitMiddleware(opts: RateLimitOptions) {
       });
       return c.json(
         {
+          success: false,
           error: {
             code: "rate_limit_exceeded",
             message: "Bạn đang gửi quá nhiều yêu cầu. Vui lòng thử lại sau.",


### PR DESCRIPTION
## Summary
- Add `success: false` to the 429 rate limit JSON response
- Aligns with the project's standard API response convention

## Related
Closes #100