### PR TITLE
fix(web): add race condition guard in AuthProvider for social login flow

### DIFF
--- a/apps/web/src/app/context/AuthProvider.tsx
+++ b/apps/web/src/app/context/AuthProvider.tsx
@@ -42,7 +42,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       if (firebaseUser) {
         // Skip /auth/me check if social login is about to set the user from /auth/social response
         if (socialLoginInProgress.current) {
-          setLoading(false);
+          // Small delay to ensure any concurrent state updates settle
+          setTimeout(() => setLoading(false), 500);
           return;
         }
         try {
@@ -112,7 +113,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       console.error("Social login error:", error);
       toast.error(error.message || "Đăng nhập thất bại");
     } finally {
-      socialLoginInProgress.current = false;
+      // Keep guard active for a short bit to prevent race with Auth observer
+      setTimeout(() => {
+        socialLoginInProgress.current = false;
+      }, 1000);
       setLoading(false);
     }
   };


### PR DESCRIPTION
## Summary
- Add 500ms delay before clearing loading state when `socialLoginInProgress` is active
- Keep `socialLoginInProgress` guard active for 1 second after login completes
- Prevents the Firebase `onAuthStateChanged` observer from racing with the
  `/api/auth/social` response and overwriting the user state

## Related
Closes #101