### PR TITLE
[FIX] Fix Vercel deployment: embed Hono API as Next.js catch-all route (#144)

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -41,7 +41,14 @@ const nextConfig: NextConfig = {
     ];
   },
 
+  // ── API Rewrites ─────────────────────────────────────────────────────
+  // In development: proxy /api/* to the separate Hono dev server (localhost:3001).
+  // In production (Vercel): /api/* is handled by the catch-all route at
+  //   src/app/api/[[...route]]/route.ts which embeds the Hono app directly.
   async rewrites() {
+    if (process.env.NODE_ENV !== 'development') {
+      return [];
+    }
     return [
       {
         source: '/api/:path*',
@@ -55,7 +62,9 @@ const nextConfig: NextConfig = {
   typescript: {
     ignoreBuildErrors: true,
   },
-  transpilePackages: ['@finance/db', '@finance/shared-schemas', '@finance/api-client'],
+  // @finance/api is included so Next.js transpiles the Hono app for the
+  // catch-all serverless route on Vercel.
+  transpilePackages: ['@finance/db', '@finance/shared-schemas', '@finance/api-client', '@finance/api'],
   // Next.js 16.2.x + pnpm monorepo workarounds for "module factory is not available"
   experimental: {
     optimizePackageImports: ['@finance/db', '@finance/shared-schemas', '@finance/api-client'],

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,8 +13,10 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
+    "@finance/api": "workspace:*",
     "@finance/api-client": "workspace:*",
     "@finance/shared-schemas": "workspace:*",
+    "@hono/zod-validator": "^0.7.6",
     "@hookform/resolvers": "^5.2.2",
     "@mui/icons-material": "^9.0.0",
     "@mui/material": "^9.0.0",
@@ -54,6 +56,7 @@
     "decimal.js": "^10.6.0",
     "embla-carousel-react": "^8.6.0",
     "firebase": "^12.12.1",
+    "hono": "^4.12.14",
     "input-otp": "^1.4.2",
     "lucide-react": "^1.8.0",
     "motion": "^12.38.0",

--- a/apps/web/src/app/api/[[...route]]/route.ts
+++ b/apps/web/src/app/api/[[...route]]/route.ts
@@ -1,0 +1,26 @@
+/**
+ * Next.js catch-all API route — delegates ALL /api/* requests to the Hono app.
+ *
+ * This is the Vercel deployment strategy: instead of a separate backend server,
+ * the Hono app is embedded directly into Next.js and served as a serverless function.
+ *
+ * Local dev still uses the separate Hono server on localhost:3001 (via next.config.ts
+ * rewrites), so this file is only active on Vercel.
+ *
+ * @see https://hono.dev/docs/getting-started/vercel
+ */
+import { handle } from 'hono/vercel';
+import app from '@finance/api';
+
+// Run as Node.js serverless function (not Edge) — required for:
+// - firebase-admin (Node.js only)
+// - pino logger
+// - @hono/node-server compatibility
+export const runtime = 'nodejs';
+
+export const GET = handle(app);
+export const POST = handle(app);
+export const PUT = handle(app);
+export const PATCH = handle(app);
+export const DELETE = handle(app);
+export const OPTIONS = handle(app);

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -26,6 +26,9 @@
     "paths": {
       "@/*": [
         "./src/*"
+      ],
+      "@finance/api": [
+        "../api/src/index.ts"
       ]
     }
   },

--- a/vercel.json
+++ b/vercel.json
@@ -3,11 +3,5 @@
   "buildCommand": "pnpm build",
   "installCommand": "pnpm install",
   "framework": "nextjs",
-  "outputDirectory": "apps/web/.next",
-  "rewrites": [
-    {
-      "source": "/api/:path*",
-      "destination": "apps/api/src/server.ts"
-    }
-  ]
+  "outputDirectory": "apps/web/.next"
 }


### PR DESCRIPTION
## Summary
Fixes the broken Vercel deployment where the API was not reachable and auth was failing.

## Changes
- Embeds Hono API into Next.js using `hono/vercel` adapter.
- Created catch-all route at `apps/web/src/app/api/[[...route]]/route.ts`.
- Fixed `vercel.json` and `next.config.ts` to support this unified deployment.
- Updated dependencies and tsconfig to allow bundling `@finance/api`.

## Related Issue
Closes #144