### PR TITLE
fix: revert firebase to static import - lazy proxy broke Google login

### DIFF
--- a/apps/web/src/_lib/firebase.ts
+++ b/apps/web/src/_lib/firebase.ts
@@ -1,17 +1,17 @@
 /**
- * Firebase initialisation — lazy-loaded to avoid blocking the main thread
- * during initial page load.
+ * Firebase initialisation.
  *
- * Before (static import):  firebase/* modules were bundled into the
- * initial chunk and parsed eagerly (~112 KB).
+ * Reverted to static imports — the dynamic import + proxy pattern caused
+ * a race condition where AuthProvider mounted before the firebase SDK
+ * finished loading, crashing Google login.
  *
- * After (dynamic import): the SDK is code-split into a separate chunk
- * that only loads when `getFirebaseApp()` or `getFirebaseAuth()` is
- * first called (i.e. when AuthProvider mounts).
+ * The main bundle-savings came from dynamic imports in layout/page and
+ * MUI removal (~650 KB total).  Firebase static import adds ~112 KB but
+ * is required for reliable auth initialization.
  */
 
-import type { FirebaseApp } from "firebase/app";
-import type { Auth, GoogleAuthProvider } from "firebase/auth";
+import { initializeApp, getApps, getApp, type FirebaseApp } from "firebase/app";
+import { getAuth, GoogleAuthProvider, type Auth } from "firebase/auth";
 
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
@@ -23,81 +23,27 @@ const firebaseConfig = {
   measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
 };
 
-// ── Module-level cache ───────────────────────────────────────────────
-let _fbApp: FirebaseApp | null = null;
-let _fbAuth: Auth | null = null;
-let _googleProvider: GoogleAuthProvider | null = null;
-
-// Preload promise — kicked off at module evaluation so by the time
-// AuthProvider calls `auth.currentUser` the SDK is already loaded.
-let _preloadPromise: Promise<void> | null = null;
-
-function preload(): Promise<void> {
-  if (_preloadPromise) return _preloadPromise;
-  _preloadPromise = (async () => {
-    if (typeof window === "undefined") return;
-    const [appModule, authModule] = await Promise.all([
-      import("firebase/app"),
-      import("firebase/auth"),
-    ]);
-    _fbApp =
-      appModule.getApps().length > 0
-        ? appModule.getApp()
-        : appModule.initializeApp(firebaseConfig);
-    _fbAuth = authModule.getAuth(_fbApp);
-    _googleProvider = new authModule.GoogleAuthProvider();
-  })();
-  return _preloadPromise;
-}
-
-// Kick off preload immediately (fire-and-forget)
-preload();
-
-// ── Public API ───────────────────────────────────────────────────────
-
+// Lazy-initialize Firebase only on the client side.
+// Running initializeApp at module level causes Turbopack SSR errors
+// ("module factory not available") because Firebase uses browser-only APIs.
 function getFirebaseApp(): FirebaseApp {
-  if (!_fbApp) {
-    if (typeof window === "undefined") {
-      throw new Error("Firebase must only be initialized in a browser context");
-    }
-    throw new Error(
-      "Firebase SDK not loaded yet — AuthProvider should call preload() before accessing auth",
-    );
+  if (typeof window === "undefined") {
+    throw new Error("Firebase must only be initialized in a browser context");
   }
-  return _fbApp;
+  return getApps().length > 0 ? getApp() : initializeApp(firebaseConfig);
 }
 
 function getFirebaseAuth(): Auth {
-  if (!_fbAuth) {
-    if (typeof window === "undefined") {
-      throw new Error("Firebase must only be initialized in a browser context");
-    }
-    throw new Error(
-      "Firebase SDK not loaded yet — AuthProvider should call preload() before accessing auth",
-    );
-  }
-  return _fbAuth;
+  return getAuth(getFirebaseApp());
 }
 
-function getGoogleProvider(): GoogleAuthProvider {
-  if (!_googleProvider) {
-    throw new Error(
-      "Firebase SDK not loaded yet — AuthProvider should call preload() before accessing auth",
-    );
-  }
-  return _googleProvider;
-}
+// Providers are stateless and safe to create eagerly
+const googleProvider = new GoogleAuthProvider();
 
-// ── Proxies (backward-compatible) ────────────────────────────────────
+// Lazy proxy for auth — evaluated only when called in the browser
 const auth = new Proxy({} as Auth, {
   get(_target, prop) {
     return Reflect.get(getFirebaseAuth(), prop);
-  },
-});
-
-const googleProvider = new Proxy({} as GoogleAuthProvider, {
-  get(_target, prop) {
-    return Reflect.get(getGoogleProvider(), prop);
   },
 });
 


### PR DESCRIPTION
Dynamic import + proxy pattern caused race condition where auth would crash before SDK loaded. Reverted to original static import pattern.