### PR TITLE
fix(web): move WalletProvider inside AuthGuard, remove wallet refetch loop

### DIFF
--- a/apps/api/src/services/budget-service.ts
+++ b/apps/api/src/services/budget-service.ts
@@ -6,7 +6,7 @@ import {
 } from "@finance/db/src/schema/budgets";
 import { transactions } from "@finance/db/src/schema/transactions";
 import { categories } from "@finance/db/src/schema/categories";
-import { and, eq, sum, gte, lte, inArray, sql, desc } from "@finance/db";
+import { and, eq, gte, lte, inArray, sql, desc } from "@finance/db";
 import Decimal from "decimal.js";
 import { NotFoundError } from "../lib/errors";
 import type { InsertBudgetInput, UpdateBudgetInput } from "@finance/shared-schemas";

--- a/apps/web/src/_lib/hooks/finance.tsx
+++ b/apps/web/src/_lib/hooks/finance.tsx
@@ -402,6 +402,10 @@ export function useWallets() {
       return walletAPI.list();
     },
     staleTime: 60 * 1000,
+    retry: (failureCount, error: any) => {
+      if (error?.status === 401) return false;
+      return failureCount < 2;
+    },
   });
 }
 

--- a/apps/web/src/app/(dashboard)/layout.tsx
+++ b/apps/web/src/app/(dashboard)/layout.tsx
@@ -10,6 +10,7 @@ import { resolveCategoryId } from '@/_lib/category-map';
 import { event as trackEvent } from '@/_lib/gtag';
 import { transactionsAPI, goalsAPI, billsAPI, budgetAPI, walletAPI } from '@finance/api-client';
 import { AuthGuard } from '@/components/layout/AuthGuard';
+import { WalletProvider } from '@/app/context/WalletContext';
 
 // ── Dynamic imports: code-split heavy components ─────────────────────
 // These are NOT needed for the initial auth check (AuthGuard only shows a
@@ -96,6 +97,20 @@ export default function DashboardLayout({
 }: {
   children: React.ReactNode;
 }) {
+  return (
+    <AuthGuard>
+      <WalletProvider>
+        <AuthenticatedDashboardShell>{children}</AuthenticatedDashboardShell>
+      </WalletProvider>
+    </AuthGuard>
+  );
+}
+
+function AuthenticatedDashboardShell({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   const [isQuickAddOpen, setIsQuickAddOpen] = useState(false);
   const { mutateAsync: createTransaction } = useCreateTransaction();
   const { data: categories = [] } = useCategories();
@@ -138,8 +153,7 @@ export default function DashboardLayout({
   };
 
   return (
-    <AuthGuard>
-      <div className="flex min-h-screen bg-gray-50">
+    <div className="flex min-h-screen bg-gray-50">
         {/* Sidebar - Desktop */}
         <Sidebar />
 
@@ -168,7 +182,6 @@ export default function DashboardLayout({
         />
 
         <Toaster position="top-right" richColors />
-      </div>
-    </AuthGuard>
+    </div>
   );
 }

--- a/apps/web/src/app/context/WalletContext.tsx
+++ b/apps/web/src/app/context/WalletContext.tsx
@@ -5,7 +5,7 @@
  * Uses TanStack Query hooks from @/_lib/hooks/finance for data fetching/mutations.
  */
 
-import { createContext, useContext, ReactNode, useMemo, useState, useCallback, useEffect } from 'react';
+import { createContext, useContext, ReactNode, useMemo, useState, useEffect } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useWallets } from '@/_lib/hooks/finance';
 import { walletAPI, Wallet } from '@finance/api-client';
@@ -59,19 +59,6 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     }
   }, [walletsData]);
 
-  // Auto-refresh when any component invalidates ['wallets']
-  useEffect(() => {
-    const unsubscribe = queryClient.getQueryCache().subscribe((event) => {
-      if (
-        event.type === 'updated' &&
-        event.query.queryKey[0] === 'wallets'
-      ) {
-        refreshWallets();
-      }
-    });
-    return () => unsubscribe();
-  }, [queryClient, refreshWallets]);
-
   const totalBalance = useMemo(() => {
     return wallets.reduce((sum, wallet) => {
       return sum.plus(new Decimal(wallet.balance || '0'));
@@ -93,7 +80,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
       });
       
       await refreshWallets();
-      queryClient.invalidateQueries({ queryKey: ['wallets'] });
+      await queryClient.invalidateQueries({ queryKey: ['wallets'] });
       toast.success('Đã thêm ví mới');
       return newWallet;
     } catch (error) {
@@ -107,7 +94,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     try {
       await walletAPI.update(id, updates);
       await refreshWallets();
-      queryClient.invalidateQueries({ queryKey: ['wallets'] });
+      await queryClient.invalidateQueries({ queryKey: ['wallets'] });
       toast.success('Đã cập nhật ví');
     } catch (error) {
       if (process.env.NODE_ENV !== 'production') console.error('Error updating wallet:', error);
@@ -120,7 +107,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     try {
       await walletAPI.delete(id);
       await refreshWallets();
-      queryClient.invalidateQueries({ queryKey: ['wallets'] });
+      await queryClient.invalidateQueries({ queryKey: ['wallets'] });
       toast.success('Đã xóa ví');
     } catch (error) {
       if (process.env.NODE_ENV !== 'production') console.error('Error deleting wallet:', error);
@@ -135,7 +122,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
       // For now, let's just update the target wallet and refresh
       await walletAPI.update(id, { isDefault: true });
       await refreshWallets();
-      queryClient.invalidateQueries({ queryKey: ['wallets'] });
+      await queryClient.invalidateQueries({ queryKey: ['wallets'] });
       toast.success('Đã đặt làm ví mặc định');
     } catch (error) {
       if (process.env.NODE_ENV !== 'production') console.error('Error setting default wallet:', error);

--- a/apps/web/src/app/providers.tsx
+++ b/apps/web/src/app/providers.tsx
@@ -4,7 +4,6 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useEffect, useState, Suspense } from 'react';
 import { usePathname, useSearchParams } from 'next/navigation';
 import { toast } from 'sonner';
-import { WalletProvider } from './context/WalletContext';
 import { AuthProvider } from './context/AuthProvider';
 import { pageview } from '@/_lib/gtag';
 
@@ -58,12 +57,10 @@ export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <QueryClientProvider client={queryClient}>
       <AuthProvider>
-        <WalletProvider>
-          <Suspense fallback={null}>
-            <AnalyticsTracker />
-          </Suspense>
-          {children}
-        </WalletProvider>
+        <Suspense fallback={null}>
+          <AnalyticsTracker />
+        </Suspense>
+        {children}
       </AuthProvider>
     </QueryClientProvider>
   );

--- a/apps/web/src/components/budgets/BudgetFormModal.tsx
+++ b/apps/web/src/components/budgets/BudgetFormModal.tsx
@@ -29,7 +29,6 @@ export interface BudgetFormData {
   endDate: string;
   isAllCategories: boolean;
   categoryIds: number[];
-  walletScope: 'all' | 'specific';
 }
 
 const PERIODS: { value: BudgetPeriod; label: string }[] = [
@@ -103,7 +102,6 @@ export function BudgetFormModal({ isOpen, onClose, onSubmit, initialData, isPend
   const [endDate, setEndDate] = useState('');
   const [isAllCategories, setIsAllCategories] = useState(false);
   const [selectedCats, setSelectedCats] = useState<number[]>([]);
-  const [walletScope, setWalletScope] = useState<'all' | 'specific'>('all');
   const [showValidationHint, setShowValidationHint] = useState(false);
 
   // Điền dữ liệu khi edit
@@ -119,7 +117,6 @@ export function BudgetFormModal({ isOpen, onClose, onSubmit, initialData, isPend
         ? initialData.categories.map((c: any) => c.id)
         : (initialData.categoryIds || []);
       setSelectedCats(catIds);
-      setWalletScope(initialData.walletScope || initialData.wallet_scope || 'all');
     } else {
       setName('');
       setLimitInput('');
@@ -129,7 +126,6 @@ export function BudgetFormModal({ isOpen, onClose, onSubmit, initialData, isPend
       setEndDate(dates.end);
       setIsAllCategories(false);
       setSelectedCats([]);
-      setWalletScope('all');
     }
     setShowValidationHint(false);
   }, [initialData, isOpen]);
@@ -172,7 +168,6 @@ export function BudgetFormModal({ isOpen, onClose, onSubmit, initialData, isPend
       endDate,
       isAllCategories,
       categoryIds: selectedCats,
-      walletScope,
     });
   };
 

--- a/packages/db/src/schema/transactions.ts
+++ b/packages/db/src/schema/transactions.ts
@@ -16,7 +16,7 @@ import { categories } from "./categories";
 import { wallets } from "./wallet";
 import { goals } from "./goals";
 
-export const transactionTypeEnum = pgEnum("transaction_type", ["income", "expense"]);
+export const transactionTypeEnum = pgEnum("transaction_type", ["income", "expense", "transfer"]);
 export const transactionSourceEnum = pgEnum("transaction_source", ["manual", "quick_add", "ocr", "import", "recurring", "bill_payment", "goal_contribution"]);
 
 export const transactions = pgTable("transactions", {

--- a/packages/shared-schemas/src/transaction.schema.ts
+++ b/packages/shared-schemas/src/transaction.schema.ts
@@ -23,7 +23,7 @@ export const insertTransactionSchema = z.object({
   // Transform -> chuẩn hóa thành string "YYYY-MM-DD" cho Drizzle DATE column
   // Tránh timezone confusion bằng cách ép dùng YYYY-MM-DD string thay vì khởi tạo Date()
   displayDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, { message: "Ngày phải có định dạng YYYY-MM-DD" }),
-  source:      z.enum(["manual", "quick_add", "ocr", "import", "recurring"]).default("manual"),
+  source:      z.enum(["manual", "quick_add", "ocr", "import", "recurring", "bill_payment", "goal_contribution"]).default("manual"),
   receiptUrl:  z.string().url().optional(),
 });
 


### PR DESCRIPTION
## Root cause

WalletProvider wrapped the entire app including /login, causing /api/v1/wallets to fire before auth completed. The 401 response triggered TanStack Query retries + WalletContext's queryCache subscription, creating an infinite refetch loop that hung the page at the spinner.

## Changes

- Remove WalletProvider from global providers.tsx
- Move WalletProvider inside AuthGuard in dashboard layout.tsx
- Remove queryCache subscribe/refetch loop in WalletContext
- Add retry guard for 401 in useWallets
- Sync schema: add bill_payment, goal_contribution to source enum; add transfer to type
- Remove legacy walletScope from BudgetFormModal
- Fix unused sum import in budget-service.ts

## Verified

- pnpm typecheck: pass (5/5)
- pnpm lint: pass (0 errors)
- pnpm build: pass