### PR TITLE
fix: stabilize auth api and dashboard loading

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "src/index.ts",
   "scripts": {
-    "dev": "tsx watch src/index.ts",
+    "dev": "tsx watch src/server.ts",
     "build": "echo \"No build required for API\"",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -11,7 +11,6 @@ import * as Sentry from '@sentry/node';
 
 // ── CORE IMPORTS ────────────────────────────────────────────────────
 import { Hono } from 'hono';
-import { serve } from '@hono/node-server';
 import { cors } from 'hono/cors';
 import { compress } from 'hono/compress';
 import type { Context } from 'hono';
@@ -256,23 +255,5 @@ app.onError((err, c) => {
     }
   }, 500);
 });
-
-// ── SERVER LIFECYCLE ──────────────────────────────────────────────
-if (process.env.NODE_ENV !== 'production') {
-  const port = Number(process.env.PORT) || 3001;
-  const server = serve({ fetch: app.fetch, port }, (info) => {
-    logger.info({ event: 'SERVER_READY', port: info.port });
-  });
-
-  const shutdown = (signal: string) => {
-    server.close(() => {
-      logger.info({ event: 'SERVER_SHUTDOWN_COMPLETE', signal });
-      process.exit(0);
-    });
-  };
-
-  process.on('SIGINT', () => shutdown('SIGINT'));
-  process.on('SIGTERM', () => shutdown('SIGTERM'));
-}
 
 export default app;

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -4,9 +4,9 @@ import app from "./index.ts";
 
 import { logger } from "./lib/logger";
 
-const port = 8787;
+const port = Number(process.env.PORT) || 3001;
 
-logger.info({ event: 'SERVER_STARTUP', message: `Finance API (Node Fallback) is running on http://localhost:${port}`, port });
+logger.info({ event: 'SERVER_STARTUP', message: `Finance API is running on http://localhost:${port}`, port });
 
 serve({
   fetch: app.fetch,

--- a/apps/web/src/app/(dashboard)/page.tsx
+++ b/apps/web/src/app/(dashboard)/page.tsx
@@ -11,54 +11,16 @@
  *
  * Removed: MultiWalletStrip (ví lớn)
  *
- * All card components are code-split via next/dynamic to reduce the
- * initial JS bundle.  Each card shows in its own Suspense boundary
- * so a slow card never blocks a fast one.
+ * Cards render directly here; each card owns its own data loading state
+ * so dashboard hydration cannot get stuck on dynamic import fallbacks.
  */
 
-import { Suspense } from 'react';
-import dynamic from 'next/dynamic';
-
-// ── Card skeleton ────────────────────────────────────────────────────
-function CardSkeleton() {
-  return (
-    <div className="animate-pulse rounded-xl border bg-white p-4 md:p-6">
-      <div className="h-5 w-1/3 rounded bg-gray-200" />
-      <div className="mt-3 h-8 w-1/2 rounded bg-gray-100" />
-    </div>
-  );
-}
-
-// ── Dynamic imports ──────────────────────────────────────────────────
-const QuickAddSection = dynamic(
-  () => import('@/components/quick-add/QuickAddSection').then((m) => ({ default: m.QuickAddSection })),
-  { ssr: false, loading: () => <CardSkeleton /> },
-);
-
-const OverviewSummaryCard = dynamic(
-  () => import('@/components/dashboard/OverviewSummaryCard').then((m) => ({ default: m.OverviewSummaryCard })),
-  { ssr: false, loading: () => <CardSkeleton /> },
-);
-
-const BudgetGrid = dynamic(
-  () => import('@/components/budgets/BudgetGrid').then((m) => ({ default: m.BudgetGrid })),
-  { ssr: false, loading: () => <CardSkeleton /> },
-);
-
-const DashboardGoalsCard = dynamic(
-  () => import('@/components/dashboard/DashboardGoalsCard').then((m) => ({ default: m.DashboardGoalsCard })),
-  { ssr: false, loading: () => <CardSkeleton /> },
-);
-
-const RecentTransactionsCard = dynamic(
-  () => import('@/components/dashboard/RecentTransactionsCard').then((m) => ({ default: m.RecentTransactionsCard })),
-  { ssr: false, loading: () => <CardSkeleton /> },
-);
-
-const UpcomingBillsCard = dynamic(
-  () => import('@/components/dashboard/UpcomingBillsCard').then((m) => ({ default: m.UpcomingBillsCard })),
-  { ssr: false, loading: () => <CardSkeleton /> },
-);
+import { QuickAddSection } from '@/components/quick-add/QuickAddSection';
+import { OverviewSummaryCard } from '@/components/dashboard/OverviewSummaryCard';
+import { BudgetGrid } from '@/components/budgets/BudgetGrid';
+import { DashboardGoalsCard } from '@/components/dashboard/DashboardGoalsCard';
+import { RecentTransactionsCard } from '@/components/dashboard/RecentTransactionsCard';
+import { UpcomingBillsCard } from '@/components/dashboard/UpcomingBillsCard';
 
 // ── Page ─────────────────────────────────────────────────────────────
 export default function DashboardPage() {


### PR DESCRIPTION
## Summary
- stop the API package from starting a local server when imported by the Next.js route handler
- move local API serving into server.ts and update the API dev script
- render dashboard cards directly so the page cannot remain stuck on dynamic import skeletons

## Verification
- pnpm typecheck
- pnpm lint
- pnpm build
- local /api/auth/me returns JSON 401 without a cookie and 200 with a valid session during dev testing