### PR TITLE
fix(mobile): prevent number overflow on iPhone 12 (390px) dashboard

### DIFF
--- a/apps/web/src/components/budgets/BudgetGrid.tsx
+++ b/apps/web/src/components/budgets/BudgetGrid.tsx
@@ -82,7 +82,7 @@ function BudgetSummaryBanner() {
           <p className="text-[10px] font-black text-blue-300 uppercase tracking-widest mb-0.5">
             Tổng quan ngân sách
           </p>
-          <p className="text-[28px] font-black text-white leading-none">
+          <p className="text-[22px] sm:text-[28px] font-black text-white leading-none truncate">
             {formatVND(numericLeft < 0 ? '0' : left)}{' '}
             <span className="text-[12px] font-bold text-blue-300">còn lại</span>
           </p>
@@ -99,12 +99,12 @@ function BudgetSummaryBanner() {
       <div className="grid grid-cols-2 gap-3 mb-4">
         <div className="bg-white/10 rounded-xl px-4 py-3">
           <p className="text-[10px] font-bold text-blue-200 mb-1 uppercase tracking-wide">Hạn mức</p>
-          <p className="text-[20px] font-black text-white leading-none">{formatVND(totalLimit)}</p>
+          <p className="text-[16px] sm:text-[20px] font-black text-white leading-none truncate">{formatVND(totalLimit)}</p>
         </div>
         <div className="bg-white/10 rounded-xl px-4 py-3">
           <p className="text-[10px] font-bold text-blue-200 mb-1 uppercase tracking-wide">Đã chi</p>
           <p
-            className="text-[20px] font-black leading-none"
+            className="text-[16px] sm:text-[20px] font-black leading-none truncate"
             style={{ color: isOver ? '#fca5a1' : isWarn ? '#fde68a' : '#6ee7b7' }}
           >
             {formatVND(totalSpent)}
@@ -203,7 +203,7 @@ function FeaturedBudgetCard({ budget }: { budget: Budget }) {
         <div>
           <div className="flex items-baseline gap-1.5">
             <span
-              className="text-[32px] font-black leading-none"
+              className="text-[24px] sm:text-[32px] font-black leading-none truncate"
               style={{ color: amountColor }}
             >
               {numericLeft < 0 ? '−' : ''}{formatVND(left.abs())}

--- a/apps/web/src/components/dashboard/DashboardGoalsCard.tsx
+++ b/apps/web/src/components/dashboard/DashboardGoalsCard.tsx
@@ -86,7 +86,7 @@ function GoalRow({ goal }: { goal: Goal }) {
           </span>
         </div>
 
-        <p className="text-[10px] font-bold text-gray-400 mb-1.5">
+        <p className="text-[10px] font-bold text-gray-400 mb-1.5 truncate">
           {formatVND(goal.currentSaved)} / {formatVND(goal.targetAmount)}
           {goal.deadline && (
             <span className="ml-1.5 text-gray-300">· {new Date(goal.deadline).toLocaleDateString('vi-VN')}</span>

--- a/apps/web/src/components/dashboard/OverviewSummaryCard.tsx
+++ b/apps/web/src/components/dashboard/OverviewSummaryCard.tsx
@@ -63,7 +63,7 @@ function StatCell({ icon, label, value, sublabel, colorText, colorBg, colorBorde
       {loading ? (
         <Skeleton className="h-[18px] w-24 bg-black/10" />
       ) : (
-        <p className="text-[18px] font-black leading-none truncate" style={{ color: colorText }}>
+        <p className="text-[15px] sm:text-[18px] font-black leading-none truncate" style={{ color: colorText }}>
           {value}
         </p>
       )}
@@ -77,8 +77,8 @@ function StatCell({ icon, label, value, sublabel, colorText, colorBg, colorBorde
     </div>
   );
 
-  if (href) return <Link href={href} className="flex-1 min-w-[130px] hover:opacity-90 transition-opacity">{inner}</Link>;
-  return <div className="flex-1 min-w-[130px]">{inner}</div>;
+  if (href) return <Link href={href} className="flex-1 sm:min-w-[130px] hover:opacity-90 transition-opacity">{inner}</Link>;
+  return <div className="flex-1 sm:min-w-[130px]">{inner}</div>;
 }
 
 export function OverviewSummaryCard() {
@@ -128,7 +128,7 @@ export function OverviewSummaryCard() {
 
   return (
     <div className="space-y-2">
-      <div className="grid grid-cols-3 gap-3">
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
         {stats.map((stat) => (
           <StatCell key={stat.label} {...stat} />
         ))}

--- a/apps/web/src/components/dashboard/RecentTransactionsCard.tsx
+++ b/apps/web/src/components/dashboard/RecentTransactionsCard.tsx
@@ -89,7 +89,7 @@ function TransactionRow({ tx, t }: { tx: Transaction; t: TFunction }) {
 
       {/* Amount */}
       <p
-        className="text-[13px] font-black shrink-0"
+        className="text-[13px] font-black shrink-0 max-w-[90px] truncate sm:max-w-none"
         style={{ color: isIncome ? '#059669' : '#dc2626' }}
       >
         {isIncome ? '+' : '−'}

--- a/apps/web/src/components/dashboard/UpcomingBillsCard.tsx
+++ b/apps/web/src/components/dashboard/UpcomingBillsCard.tsx
@@ -78,7 +78,7 @@ export function UpcomingBillsCard() {
                     {overdue ? t('dashboard.bills.overdue') : t('dashboard.bills.monthlyDue').replace('{{day}}', bill.dueDay.toString())}
                   </p>
                 </div>
-                <p className="text-[12px] font-black text-gray-800 shrink-0">
+                <p className="text-[12px] font-black text-gray-800 shrink-0 max-w-[85px] truncate sm:max-w-none">
                   {formatVND(bill.amount)}
                 </p>
               </div>

--- a/apps/web/src/components/quick-add/SimpleQuickInput.tsx
+++ b/apps/web/src/components/quick-add/SimpleQuickInput.tsx
@@ -320,7 +320,7 @@ export function SimpleQuickInput() {
 
       {/* ── Row 3: Amount + Note + Submit ── */}
       <div className="flex items-center gap-3 px-5 py-4 border-b border-gray-100">
-        <div className="relative shrink-0 w-[180px]">
+        <div className="relative shrink-0 w-[110px] sm:w-[180px]">
           <CurrencyInput
             value={amount}
             onValueChange={setAmount}


### PR DESCRIPTION
## Changes
All changes use responsive sm: prefix — desktop unchanged.

- **OverviewSummaryCard**: grid-cols-1 sm:grid-cols-3, value text-[15px] sm:text-[18px]
- **FeaturedBudgetCard**: số còn lại text-[24px] sm:text-[32px] + truncate
- **SimpleQuickInput**: amount input w-[110px] sm:w-[180px]
- **RecentTransactionsCard + UpcomingBillsCard**: amount max-w-[90px] truncate sm:max-w-none
- **DashboardGoalsCard**: progress text thêm truncate
- **BudgetSummaryBanner**: text-[22px] sm:text-[28px], stats text-[16px] sm:text-[20px]

## Verified
- pnpm typecheck: pass (5/5)
- pnpm lint: pass (0 errors)