### PR TITLE
Fix login error visibility and Firebase OAuth client

### DIFF
--- a/apps/web/src/app/providers.tsx
+++ b/apps/web/src/app/providers.tsx
@@ -3,7 +3,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useEffect, useState, Suspense } from 'react';
 import { usePathname, useSearchParams } from 'next/navigation';
-import { toast } from 'sonner';
+import { Toaster, toast } from 'sonner';
 import { AuthProvider } from './context/AuthProvider';
 import { pageview } from '@/_lib/gtag';
 
@@ -62,6 +62,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
         </Suspense>
         {children}
       </AuthProvider>
+      <Toaster position="top-right" richColors />
     </QueryClientProvider>
   );
 }


### PR DESCRIPTION
## Summary
- show Sonner toasts globally so login/auth errors are visible on /login
- production/development Vercel NEXT_PUBLIC_GOOGLE_CLIENT_ID updated back to the Firebase project OAuth client

## Verification
- pnpm --filter web typecheck
- pnpm --filter web build
- GitNexus impact/detect_changes reviewed for Providers