### PR TITLE
fix(auth): await firebase persistence before auth ops

### DIFF
--- a/apps/web/src/_lib/firebase.ts
+++ b/apps/web/src/_lib/firebase.ts
@@ -40,19 +40,34 @@ function getFirebaseApp(): FirebaseApp {
 }
 
 let _auth: Auth | null = null;
+let _persistenceReady: Promise<void> | null = null;
 
 function getFirebaseAuth(): Auth {
   if (!_auth) {
     _auth = getAuth(getFirebaseApp());
     // localStorage survives cross-origin redirects on mobile (Safari / Chrome);
     // sessionStorage is often cleared, causing "missing initial state".
-    setPersistence(_auth, browserLocalPersistence).catch((err) => {
+    _persistenceReady = setPersistence(_auth, browserLocalPersistence).catch((err) => {
       if (process.env.NODE_ENV !== "production") {
         console.warn("Failed to set auth persistence:", err);
       }
+      // Resolve anyway — app can limp on with default persistence.
     });
   }
   return _auth;
+}
+
+/**
+ * Returns a promise that resolves once Firebase Auth persistence is
+ * configured.  Callers MUST await this before any sign-in operation;
+ * otherwise Firebase uses its default (IndexedDB), which Safari's ITP
+ * and Private Mode may block, causing in-memory-only auth state that
+ * evaporates on navigation.
+ */
+export function whenPersistenceReady(): Promise<void> {
+  // Touch auth so _persistenceReady is initialised
+  getFirebaseAuth();
+  return _persistenceReady ?? Promise.resolve();
 }
 
 // Providers are stateless and safe to create eagerly

--- a/apps/web/src/app/context/AuthProvider.tsx
+++ b/apps/web/src/app/context/AuthProvider.tsx
@@ -11,7 +11,7 @@ import {
   signOut as firebaseSignOut, 
   AuthProvider as FirebaseAuthProvider
 } from "firebase/auth";
-import { auth, googleProvider } from "../../_lib/firebase";
+import { auth, googleProvider, whenPersistenceReady } from "../../_lib/firebase";
 import { initiateGoogleOAuth, consumeGoogleOAuthState } from "../../_lib/google-oauth";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
@@ -35,13 +35,6 @@ interface AuthContextType {
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
-function isSafariLikeBrowser(): boolean {
-  if (typeof navigator === "undefined") return false;
-
-  const userAgent = navigator.userAgent;
-  return /Safari/i.test(userAgent) && !/Chrome|Chromium|CriOS|FxiOS|Edg/i.test(userAgent);
-}
-
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
@@ -53,7 +46,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     let unsub: (() => void) | undefined;
 
     (async () => {
-      // 0. Process custom Google OAuth redirect (Safari-compatible — bypasses
+      // 0. Wait for Firebase persistence to be configured before any auth
+      //    operation.  Without this, Firebase uses its default (IndexedDB)
+      //    which Safari ITP / Private Mode may block → in-memory auth state
+      //    evaporates on navigation → user appears signed out.
+      await whenPersistenceReady();
+      if (cancelled) return;
+
+      // 1. Process custom Google OAuth redirect (Safari-compatible — bypasses
       //    Firebase's signInWithRedirect which relies on sessionStorage).
       try {
         const oauthResult = consumeGoogleOAuthState();
@@ -108,7 +108,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         // No pending OAuth redirect — continue below
       }
 
-      // 1. Process Firebase redirect result (legacy mobile fallback).
+      // 2. Process Firebase redirect result (legacy mobile fallback).
       //    Must run before onAuthStateChanged to avoid race.
       try {
         const result = await getRedirectResult(auth);
@@ -148,7 +148,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
       if (cancelled) return;
 
-      // 2. Auth state listener (normal page loads & popup flows)
+      // 3. Auth state listener (normal page loads & popup flows)
       unsub = onAuthStateChanged(auth, async (firebaseUser) => {
         if (firebaseUser) {
           // Skip /auth/me check if social login is about to set the user from /auth/social response
@@ -223,11 +223,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     socialLoginInProgress.current = true;
     try {
       setLoading(true);
-
-      if (isSafariLikeBrowser()) {
-        initiateGoogleOAuth();
-        return;
-      }
 
       let result;
       try {


### PR DESCRIPTION
- Await Firebase Auth persistence configuration before any auth operation (prevents Safari/Private Mode losing auth state).

Changes:
- apps/web/src/_lib/firebase.ts: expose whenPersistenceReady()
- apps/web/src/app/context/AuthProvider.tsx: await whenPersistenceReady() before redirect result/auth listener
